### PR TITLE
Generate files and create dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ missing
 test-driver
 cron/refile-and-grok.sh
 grapher/update-dat-file-locations.sh
+extractor/put-file.pl
+grapher/dsc-grapher-cli.pl
+grapher/dsc-grapher.pl

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,9 +8,9 @@ EXTRA_DIST = certs doc m4 autogen.sh
 
 if DSC_CREATE_DIRS
 install-data-local:
-	mkdir -p "$(prefix)/var/log" \
-      "$(prefix)/data" \
-      "$(prefix)/cache"
+	mkdir -p "$(DSP_LOG_DIR)" \
+      "$(DSC_DATA_DIR)" \
+      "$(DSP_CACHE_DIR)"
 endif
 
 test:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ prefix=/usr/local/dsc
     --with-html-dir=$prefix/share/html \
     --with-etc-dir=$prefix/etc \
     --with-libexec-dir=$prefix/libexec \
+    --with-cache-dir=$prefix/cache \
+    --with-log-dir=$prefix/var/log \
     --enable-create-dirs
 make
 make install
@@ -81,3 +83,6 @@ for more information.
 make
 make install
 ```
+
+You can use `--enable-create-dirs` to create the necessary directories upon
+installation.

--- a/configure.ac
+++ b/configure.ac
@@ -35,7 +35,7 @@
 AC_PREREQ(2.61)
 AC_INIT([DSP], [2.0.0], [dsc@dns-oarc.net], [dsp], [https://github.com/DNS-OARC/dsp/issues])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
-AC_CONFIG_SRCDIR([grapher/dsc-grapher-cli.pl])
+AC_CONFIG_SRCDIR([grapher/dsc-grapher.pl.in])
 AC_CONFIG_MACRO_DIR([m4])
 
 # Checks for programs.
@@ -106,10 +106,28 @@ AC_ARG_WITH(libexec-dir,
 
 AC_SUBST([DSP_LIBEXEC_DIR], [$with_libexec_dir])
 
+# cache dir
+AC_ARG_WITH(cache-dir,
+    [AS_HELP_STRING([--with-cache-dir=DIR],
+        [use DIR for cache [LOCALSTATEDIR/cache/dsp]])],
+    [],
+    [with_cache_dir=${localstatedir}/cache/dsp])
+
+AC_SUBST([DSP_CACHE_DIR], [$with_cache_dir])
+
+# log dir
+AC_ARG_WITH(log-dir,
+    [AS_HELP_STRING([--with-log-dir=DIR],
+        [use DIR for logs [LOCALSTATEDIR/log/dsp]])],
+    [],
+    [with_cache_dir=${localstatedir}/log/dsp])
+
+AC_SUBST([DSP_LOG_DIR], [$with_log_dir])
+
 # create dirs
 AC_ARG_ENABLE(create-dirs,
     [AS_HELP_STRING([--enable-create-dirs],
-        [create directories as pre 2.0.0 [PREFIX/(var/log|data|cache)]])],
+        [create data, cache and log directories on installation])],
     [case "${enableval}" in
         yes)
             create_dirs=true

--- a/extractor/Makefile.am
+++ b/extractor/Makefile.am
@@ -5,4 +5,11 @@ dist_script_SCRIPTS = dsc-xml-extractor.pl \
     fix-corrupted-dat-files.pl
 
 cgibindir = $(DSP_CGI_BIN_DIR)
-dist_cgibin_SCRIPTS = put-file.pl
+cgibin_SCRIPTS = put-file.pl
+
+EXTRA_DIST = put-file.pl.in
+
+put-file.pl: put-file.pl.in Makefile
+	sed -e 's,[@]DSC_DATA_DIR[@],$(DSC_DATA_DIR),g' \
+        -e 's,[@]DSP_LOG_DIR[@],$(DSP_LOG_DIR),g' \
+        < $(srcdir)/put-file.pl.in > put-file.pl

--- a/extractor/fix-corrupted-dat-files.pl
+++ b/extractor/fix-corrupted-dat-files.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 #
 # Copyright (c) 2016, OARC, Inc.
 # Copyright (c) 2007, The Measurement Factory, Inc.

--- a/extractor/put-file.pl.in
+++ b/extractor/put-file.pl.in
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 # Copyright (c) 2016, OARC, Inc.
 # Copyright (c) 2007, The Measurement Factory, Inc.
@@ -36,32 +36,11 @@
 
 use strict;
 use warnings;
-use Getopt::Long;
-use DSC::grapher;
+use DSC::putfile;
 
-our $ploticus_debug=1;
+# $DSC::putfile::debug =
+$DSC::putfile::putlog = '@DSP_LOG_DIR@/put-file.log';
+$DSC::putfile::TOPDIR = '@DSC_DATA_DIR@';
 
-my %args;
-my $result = GetOptions (\%args,
-			"server=s",
-			"node=s",
-			"window=s",
-			"binsize=i",
-			"plot=s",
-			"end=i",
-			"yaxis=s",
-			"key=s",
-			'configfile=s',
-			'dataroot=s',
-			'cachepath=s',
-			'htmlpath=s',
-			);
-
-my $grapher = DSC::grapher->new(
-    $args{dataroot} ? ( dataroot => $args{dataroot} ) : (),
-    $args{configfile} ? ( configfile => $args{configfile} ) : (),
-    $args{cachepath} ? ( cachepath => $args{cachepath} ) : (),
-    $args{htmlpath} ? ( htmlpath => $args{htmlpath} ) : (),
-);
-$grapher->cmdline(\%args);
-$grapher->run();
+DSC::putfile::run();
+exit 0;

--- a/grapher/Makefile.am
+++ b/grapher/Makefile.am
@@ -3,10 +3,10 @@ MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
 CLEANFILES = update-dat-file-locations.sh
 
 scriptdir = $(DSP_LIBEXEC_DIR)
-dist_script_SCRIPTS = dsc-grapher-cli.pl
+script_SCRIPTS = dsc-grapher-cli.pl
 
 cgibindir = $(DSP_CGI_BIN_DIR)
-dist_cgibin_SCRIPTS = dsc-grapher.pl
+cgibin_SCRIPTS = dsc-grapher.pl
 
 etcdir = $(DSP_ETC_DIR)
 dist_etc_DATA = dsc-grapher.cfg.sample
@@ -22,10 +22,26 @@ dist_html_DATA = plot.page \
     icons/2rightarrow.png \
     icons/2uparrow.png
 
-script_SCRIPTS = update-dat-file-locations.sh
+script_SCRIPTS += update-dat-file-locations.sh
 
-EXTRA_DIST = update-dat-file-locations.sh.in
+EXTRA_DIST = update-dat-file-locations.sh.in \
+    dsc-grapher-cli.pl.in \
+    dsc-grapher.pl.in
 
 update-dat-file-locations.sh: update-dat-file-locations.sh.in Makefile
 	sed -e 's,[@]DSC_DATA_DIR[@],$(DSC_DATA_DIR),g' \
         < $(srcdir)/update-dat-file-locations.sh.in > update-dat-file-locations.sh
+
+dsc-grapher-cli.pl: dsc-grapher-cli.pl.in Makefile
+	sed -e 's,[@]DSC_DATA_DIR[@],$(DSC_DATA_DIR),g' \
+        -e 's,[@]DSP_ETC_DIR[@],$(DSP_ETC_DIR),g' \
+        -e 's,[@]DSP_CACHE_DIR[@],$(DSP_CACHE_DIR),g' \
+        -e 's,[@]DSP_HTML_DIR[@],$(DSP_HTML_DIR),g' \
+        < $(srcdir)/dsc-grapher-cli.pl.in > dsc-grapher-cli.pl
+
+dsc-grapher.pl: dsc-grapher.pl.in Makefile
+	sed -e 's,[@]DSC_DATA_DIR[@],$(DSC_DATA_DIR),g' \
+        -e 's,[@]DSP_ETC_DIR[@],$(DSP_ETC_DIR),g' \
+        -e 's,[@]DSP_CACHE_DIR[@],$(DSP_CACHE_DIR),g' \
+        -e 's,[@]DSP_HTML_DIR[@],$(DSP_HTML_DIR),g' \
+        < $(srcdir)/dsc-grapher.pl.in > dsc-grapher.pl

--- a/grapher/dsc-grapher-cli.pl.in
+++ b/grapher/dsc-grapher-cli.pl.in
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 # Copyright (c) 2016, OARC, Inc.
 # Copyright (c) 2007, The Measurement Factory, Inc.
@@ -22,7 +22,7 @@
 #    from this software without specific prior written permission.
 #
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# 'AS IS' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
 # FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
 # COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
@@ -36,14 +36,32 @@
 
 use strict;
 use warnings;
-use CGI;
-
+use Getopt::Long;
 use DSC::grapher;
-my $grapher = DSC::grapher->new(
-# dataroot => 'path',
-# configfile => 'path',
-# cachepath => 'path',
-# htmlpath => 'path',
+
+our $ploticus_debug=1;
+
+my %args;
+my $result = GetOptions (\%args,
+    'server=s',
+    'node=s',
+    'window=s',
+    'binsize=i',
+    'plot=s',
+    'end=i',
+    'yaxis=s',
+    'key=s',
+    'configfile=s',
+    'dataroot=s',
+    'cachepath=s',
+    'htmlpath=s',
 );
-$grapher->cgi(new CGI);
+
+my $grapher = DSC::grapher->new(
+    dataroot => $args{dataroot} ? $args{dataroot} : '@DSC_DATA_DIR@',
+    configfile => $args{configfile} ? $args{configfile} : '@DSP_ETC_DIR@/dsc-grapher.cfg',
+    cachepath => $args{cachepath} ? $args{cachepath} : '@DSP_CACHE_DIR@',
+    htmlpath => $args{htmlpath} ? $args{htmlpath} : '@DSP_HTML_DIR@',
+);
+$grapher->cmdline(\%args);
 $grapher->run();

--- a/grapher/dsc-grapher.pl.in
+++ b/grapher/dsc-grapher.pl.in
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 #
 # Copyright (c) 2016, OARC, Inc.
 # Copyright (c) 2007, The Measurement Factory, Inc.
@@ -36,11 +36,14 @@
 
 use strict;
 use warnings;
-use DSC::putfile;
+use CGI;
 
-# $DSC::putfile::debug =
-# $DSC::putfile::putlog =
-# $DSC::putfile::TOPDIR =
-
-DSC::putfile::run();
-exit 0;
+use DSC::grapher;
+my $grapher = DSC::grapher->new(
+    dataroot => '@DSC_DATA_DIR@',
+    configfile => '@DSP_ETC_DIR@/dsc-grapher.cfg',
+    cachepath => '@DSP_CACHE_DIR@',
+    htmlpath => '@DSP_HTML_DIR@',
+);
+$grapher->cgi(new CGI);
+$grapher->run();


### PR DESCRIPTION
Generate put-file and dsc-grapher with the configured paths.
Add configure option for cache and log path.
--enable-create-dirs now to create dirs for both pre and post 2.0.0.
Use perl shebang in all files and remove perl warnings.
